### PR TITLE
Add shared Prometheus metrics and backend ingestion instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ infrastructure (Kafka, Zookeeper, RTSP server, MongoDB) is provided via Docker C
 - FastAPI Backend (orchestrator + UI)
     - Starts/stops services, manages Kafka topics, exposes dashboard and APIs
 
+All FastAPI services (backend and AI microservices) expose Prometheus metrics at `/metrics` for scraping.
+
 ## Quick start (with Docker infrastructure)
 
 1) Start base services via Docker (Kafka, Zookeeper, RTSP, MongoDB)
@@ -138,6 +140,8 @@ Backend APIs (selected)
 - Annotation helpers
     - GET `/api/annotation/{task_id}/rtsp_url`, `/api/annotation/{task_id}/videos`,
       `/api/annotation/{task_id}/download/{filename}`, `/api/annotation/{task_id}/status`
+- Observability
+    - GET `/metrics` Prometheus metrics for the backend (each AI microservice exposes the same endpoint)
 
 Data formats (high level)
 

--- a/apps/annotation_service/service.py
+++ b/apps/annotation_service/service.py
@@ -60,10 +60,28 @@ class AnnotationService(BaseAIService):
         logger.info(f"Tracking topic: {track_config.get('topic')}")
 
         return [
-            KafkaInput(raw_config),
+            KafkaInput(
+                raw_config,
+                metrics_service=self.get_service_name(),
+                metrics_task_id=self.task_id,
+                metrics_topic=raw_config.get('topic'),
+                metrics_worker_id='input-raw',
+            ),
             # KafkaInput(det_config),
-            KafkaInput(pose_config),
-            KafkaInput(track_config)
+            KafkaInput(
+                pose_config,
+                metrics_service=self.get_service_name(),
+                metrics_task_id=self.task_id,
+                metrics_topic=pose_config.get('topic'),
+                metrics_worker_id='input-pose',
+            ),
+            KafkaInput(
+                track_config,
+                metrics_service=self.get_service_name(),
+                metrics_task_id=self.task_id,
+                metrics_topic=track_config.get('topic'),
+                metrics_worker_id='input-track',
+            )
         ]
 
     def create_output_interface(self) -> MultiOutputInterface:

--- a/apps/bytetrack_service/service.py
+++ b/apps/bytetrack_service/service.py
@@ -74,7 +74,15 @@ class ByteTrackService(BaseAIService):
                         'input_name': input_name  # Add input name for identification
                     }
 
-                    interfaces.append(KafkaInput(config=final_config))
+                    interfaces.append(
+                        KafkaInput(
+                            config=final_config,
+                            metrics_service=self.get_service_name(),
+                            metrics_task_id=self.task_id,
+                            metrics_topic=final_config.get('topic'),
+                            metrics_worker_id=f"input-{input_name}",
+                        )
+                    )
                     logger.info(
                         f"{input_name} input - Topic: {final_config.get('topic')}, Group: {final_config.get('group_id')}")
         else:
@@ -82,7 +90,14 @@ class ByteTrackService(BaseAIService):
             input_config = self._get_kafka_input_config()
             logger.info(f"Legacy input topic: {input_config.get('topic')}")
             logger.info(f"Legacy consumer group: {input_config.get('group_id')}")
-            interfaces.append(KafkaInput(config=input_config))
+            interfaces.append(
+                KafkaInput(
+                    config=input_config,
+                    metrics_service=self.get_service_name(),
+                    metrics_task_id=self.task_id,
+                    metrics_topic=input_config.get('topic'),
+                )
+            )
 
         return interfaces
 
@@ -93,7 +108,12 @@ class ByteTrackService(BaseAIService):
         output_config = self._get_kafka_output_config()
         logger.info(f"Output topic: {output_config.get('topic')}")
 
-        return KafkaOutput(config=output_config)
+        return KafkaOutput(
+            config=output_config,
+            metrics_service=self.get_service_name(),
+            metrics_task_id=self.task_id,
+            metrics_topic=output_config.get('topic'),
+        )
 
     def get_model_config(self) -> dict:
         """Get BoTSORT model configuration."""

--- a/apps/fastapi_backend/metrics.py
+++ b/apps/fastapi_backend/metrics.py
@@ -1,0 +1,131 @@
+"""Prometheus metrics for the FastAPI backend service."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from contanos.metrics.prometheus import LABEL_NAMES, MetricsLabelContext
+
+
+BACKEND_SERVICE_NAME = "fastapi_backend"
+
+
+def _create_context(worker_id: str, topic: str, task_id: Optional[str] = None) -> MetricsLabelContext:
+    """Create a metrics label context scoped to this backend service."""
+
+    return MetricsLabelContext(
+        service=BACKEND_SERVICE_NAME,
+        worker_id=worker_id,
+        topic=topic,
+        initial_task_id=task_id,
+    )
+
+
+def create_task_context(task_id: Optional[str]) -> MetricsLabelContext:
+    """Return a metrics context for task orchestration stages."""
+
+    return _create_context(worker_id="task_manager", topic="backend_tasks", task_id=task_id)
+
+
+def create_wait_context(task_id: Optional[str]) -> MetricsLabelContext:
+    """Return a metrics context for simulated task completion waiting."""
+
+    return _create_context(worker_id="task_waiter", topic="backend_wait", task_id=task_id)
+
+
+def create_video_publish_context(topic: str, task_id: Optional[str]) -> MetricsLabelContext:
+    """Return a metrics context for publishing video segments to Kafka."""
+
+    return _create_context(worker_id="video_ingest", topic=topic, task_id=task_id)
+
+
+# Video ingestion metrics ---------------------------------------------------
+
+backend_segment_extraction_seconds = Histogram(
+    "backend_segment_extraction_seconds",
+    "Time spent extracting video segments with FFmpeg before publishing to Kafka.",
+    LABEL_NAMES,
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 40.0),
+)
+
+backend_segment_publish_seconds = Histogram(
+    "backend_segment_publish_seconds",
+    "Time spent awaiting Kafka acknowledgement for published video segments.",
+    LABEL_NAMES,
+    buckets=(0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0),
+)
+
+backend_segments_sent_total = Counter(
+    "backend_segments_sent_total",
+    "Total number of video segments successfully published to Kafka by the backend.",
+    LABEL_NAMES,
+)
+
+backend_segment_bytes_sent_total = Counter(
+    "backend_segment_bytes_sent_total",
+    "Total bytes of encoded video segments sent to Kafka by the backend.",
+    LABEL_NAMES,
+)
+
+backend_segment_failures_total = Counter(
+    "backend_segment_failures_total",
+    "Total number of failures encountered during segment extraction or publishing.",
+    LABEL_NAMES,
+)
+
+
+# Task orchestration metrics ------------------------------------------------
+
+backend_active_tasks = Gauge(
+    "backend_active_tasks",
+    "Number of video processing tasks currently managed by the backend.",
+    LABEL_NAMES,
+)
+
+backend_task_progress_percent = Gauge(
+    "backend_task_progress_percent",
+    "Latest reported progress percentage for backend managed tasks.",
+    LABEL_NAMES,
+)
+
+backend_task_total_duration_seconds = Histogram(
+    "backend_task_total_duration_seconds",
+    "Total runtime of backend managed video processing tasks.",
+    LABEL_NAMES,
+    buckets=(5, 10, 30, 60, 120, 300, 600, 900, 1800),
+)
+
+backend_task_upload_seconds = Histogram(
+    "backend_task_upload_seconds",
+    "Time spent in the upload stage before backend processing begins.",
+    LABEL_NAMES,
+    buckets=(1, 5, 10, 30, 60, 120, 300, 600),
+)
+
+backend_task_publish_seconds = Histogram(
+    "backend_task_publish_seconds",
+    "Time spent publishing video segments to Kafka for a task.",
+    LABEL_NAMES,
+    buckets=(1, 5, 10, 30, 60, 120, 300),
+)
+
+backend_task_wait_seconds = Histogram(
+    "backend_task_wait_seconds",
+    "Time spent waiting for downstream AI services to finish a task.",
+    LABEL_NAMES,
+    buckets=(5, 10, 30, 60, 120, 300, 600, 900),
+)
+
+backend_completion_timeouts_total = Counter(
+    "backend_completion_timeouts_total",
+    "Total number of simulated completion waits that expired before downstream confirmation.",
+    LABEL_NAMES,
+)
+
+backend_completion_failures_total = Counter(
+    "backend_completion_failures_total",
+    "Total number of simulated completion waits that failed due to unexpected errors.",
+    LABEL_NAMES,
+)

--- a/apps/fastapi_backend/tasks.py
+++ b/apps/fastapi_backend/tasks.py
@@ -7,8 +7,22 @@ Background tasks for video processing pipeline.
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Dict
+from time import perf_counter
+from typing import Dict, Optional
 
+from apps.fastapi_backend.metrics import (
+    backend_active_tasks,
+    backend_completion_failures_total,
+    backend_completion_timeouts_total,
+    backend_task_progress_percent,
+    backend_task_publish_seconds,
+    backend_task_total_duration_seconds,
+    backend_task_upload_seconds,
+    backend_task_wait_seconds,
+    create_task_context,
+    create_wait_context,
+)
+from contanos.metrics.prometheus import MetricsLabelContext
 from kafka_controller import KafkaController
 from schemas import TaskStatus
 from video_utils import extract_and_publish_async
@@ -25,27 +39,44 @@ async def process_video_task(task_id: str,
     """
     logger.info(f"🚀 Starting video processing for task {task_id}")
 
-    try:
-        # Update status to processing
-        if task_id in status_db:
-            status_db[task_id].status = "processing"
-            status_db[task_id].progress = 10
-            status_db[task_id].updated_at = datetime.now(timezone.utc)
+    metrics_context = create_task_context(task_id)
+    labels = metrics_context.labels_for(task_id)
+    backend_active_tasks.labels(**labels).inc()
+    total_start = perf_counter()
 
-        # Extract and publish frames
-        # Extract and publish video segments to Kafka
+    try:
+        now = datetime.now(timezone.utc)
+        if task_id in status_db:
+            task_status = status_db[task_id]
+            if task_status.created_at:
+                upload_duration = (now - task_status.created_at).total_seconds()
+                if upload_duration >= 0:
+                    backend_task_upload_seconds.labels(**labels).observe(upload_duration)
+            backend_task_progress_percent.labels(**labels).set(task_status.progress)
+            task_status.status = "processing"
+            task_status.progress = 10
+            task_status.updated_at = now
+            backend_task_progress_percent.labels(**labels).set(task_status.progress)
+        else:
+            backend_task_progress_percent.labels(**labels).set(0)
+
+        # Update status to processing
         logger.info(f"🎞 Extracting & publishing from {video_path}")
+        publish_start = perf_counter()
         await extract_and_publish_async(
             video_path=video_path,
             task_id=task_id,
             segment_time=2.0,
             bootstrap_servers=kafka_controller.bootstrap_servers
         )
+        publish_duration = perf_counter() - publish_start
+        backend_task_publish_seconds.labels(**labels).observe(publish_duration)
 
         # Update progress
         if task_id in status_db:
             status_db[task_id].progress = 50
             status_db[task_id].updated_at = datetime.now(timezone.utc)
+            backend_task_progress_percent.labels(**labels).set(status_db[task_id].progress)
 
         # Wait for AI services to process
         # In production, this would monitor the bytetrack topic for completion
@@ -53,7 +84,17 @@ async def process_video_task(task_id: str,
         # TODO: Implement proper completion detection
         # For now, we'll simulate with a timeout
         logger.info("📡 Waiting for AI services to complete processing...")
-        await wait_for_completion(task_id, timeout_seconds=120, status_db=status_db)
+        wait_context = create_wait_context(task_id)
+        wait_start = perf_counter()
+        await wait_for_completion(
+            task_id,
+            timeout_seconds=120,
+            status_db=status_db,
+            metrics_context=wait_context,
+            progress_labels=labels,
+        )
+        wait_duration = perf_counter() - wait_start
+        backend_task_wait_seconds.labels(**labels).observe(wait_duration)
 
         # Generate output file path
         # output_path = Path(f"/tmp/video_outputs/{task_id}_output.mp4")
@@ -64,6 +105,7 @@ async def process_video_task(task_id: str,
             status_db[task_id].status = "completed"
             status_db[task_id].progress = 100
             status_db[task_id].updated_at = datetime.now(timezone.utc)
+            backend_task_progress_percent.labels(**labels).set(status_db[task_id].progress)
 
         logger.info(f"✅ Task {task_id} completed successfully.")
 
@@ -81,28 +123,71 @@ async def process_video_task(task_id: str,
             status_db[task_id].error = str(e)
 
             status_db[task_id].updated_at = datetime.now(timezone.utc)
+            backend_task_progress_percent.labels(**labels).set(status_db[task_id].progress)
 
         kafka_controller.delete_topics_for_task(task_id, delay_seconds=10 * 60)
 
+    finally:
+        total_duration = perf_counter() - total_start
+        backend_task_total_duration_seconds.labels(**labels).observe(total_duration)
+        backend_active_tasks.labels(**labels).dec()
+        backend_task_progress_percent.labels(**labels).set(0)
 
-async def wait_for_completion(task_id: str,
-                              timeout_seconds: int = 300,
-                              status_db: Dict[str, TaskStatus] = None):
+
+async def wait_for_completion(
+    task_id: str,
+    timeout_seconds: int = 300,
+    status_db: Optional[Dict[str, TaskStatus]] = None,
+    *,
+    metrics_context: Optional[MetricsLabelContext] = None,
+    progress_labels: Optional[Dict[str, str]] = None,
+) -> None:
     """
     Async wait for downstream services to process the video (simulated).
     In real system: monitor Kafka topic progress or completion flag.
     """
-    start_time = asyncio.get_event_loop().time()
+    loop = asyncio.get_event_loop()
+    start_time = loop.time()
     check_interval = 5
 
-    while asyncio.get_event_loop().time() - start_time < timeout_seconds:
-        elapsed = asyncio.get_event_loop().time() - start_time
-        progress = min(50 + (elapsed / timeout_seconds) * 40, 90)
+    labels = None
+    if metrics_context is not None:
+        labels = metrics_context.labels_for(task_id)
+        if progress_labels is None:
+            progress_labels = labels
 
-        if status_db and task_id in status_db:
-            status_db[task_id].progress = int(progress)
-            status_db[task_id].updated_at = datetime.now(timezone.utc)
+    timed_out = True
 
-        await asyncio.sleep(check_interval)
+    try:
+        while loop.time() - start_time < timeout_seconds:
+            elapsed = loop.time() - start_time
+            progress = min(50 + (elapsed / timeout_seconds) * 40, 90)
 
-    logger.info(f"⌛️ Completion wait finished for task {task_id}")
+            if status_db and task_id in status_db:
+                status_db[task_id].progress = int(progress)
+                status_db[task_id].updated_at = datetime.now(timezone.utc)
+
+            if progress_labels is not None:
+                backend_task_progress_percent.labels(**progress_labels).set(int(progress))
+
+            await asyncio.sleep(check_interval)
+
+    except Exception:
+        timed_out = False
+        if labels is not None:
+            backend_completion_failures_total.labels(**labels).inc()
+        raise
+
+    else:
+        if timed_out:
+            if status_db and task_id in status_db:
+                status_db[task_id].progress = 90
+                status_db[task_id].updated_at = datetime.now(timezone.utc)
+
+            if progress_labels is not None:
+                backend_task_progress_percent.labels(**progress_labels).set(90)
+
+            if labels is not None:
+                backend_completion_timeouts_total.labels(**labels).inc()
+
+        logger.info(f"⌛️ Completion wait finished for task {task_id}")

--- a/apps/rtmpose_service/service.py
+++ b/apps/rtmpose_service/service.py
@@ -50,8 +50,20 @@ class RTMPoseService(BaseAIService):
         logger.info(f"Detections input topic: {detections_config.get('topic')}")
 
         return [
-            KafkaInput(config=frames_config),
-            KafkaInput(config=detections_config)
+            KafkaInput(
+                config=frames_config,
+                metrics_service=self.get_service_name(),
+                metrics_task_id=self.task_id,
+                metrics_topic=frames_config.get('topic'),
+                metrics_worker_id='input-frames',
+            ),
+            KafkaInput(
+                config=detections_config,
+                metrics_service=self.get_service_name(),
+                metrics_task_id=self.task_id,
+                metrics_topic=detections_config.get('topic'),
+                metrics_worker_id='input-detections',
+            )
         ]
 
     def create_output_interface(self) -> KafkaOutput:
@@ -59,7 +71,12 @@ class RTMPoseService(BaseAIService):
         output_config = self._get_kafka_output_config()
         logger.info(f"Output topic: {output_config.get('topic')}")
 
-        return KafkaOutput(config=output_config)
+        return KafkaOutput(
+            config=output_config,
+            metrics_service=self.get_service_name(),
+            metrics_task_id=self.task_id,
+            metrics_topic=output_config.get('topic'),
+        )
 
     def get_model_config(self) -> Dict[str, Any]:
         """Get RTMPose model configuration."""

--- a/apps/yolox_service/service.py
+++ b/apps/yolox_service/service.py
@@ -47,14 +47,26 @@ class YOLOXService(BaseAIService):
         logger.info(f"Input topic: {input_config.get('topic')}")
         logger.info(f"Consumer group: {input_config.get('group_id')}")
 
-        return [KafkaInput(config=input_config)]
+        return [
+            KafkaInput(
+                config=input_config,
+                metrics_service=self.get_service_name(),
+                metrics_task_id=self.task_id,
+                metrics_topic=input_config.get('topic'),
+            )
+        ]
 
     def create_output_interface(self) -> KafkaOutput:
         """Create Kafka output interface for detections."""
         output_config = self._get_kafka_output_config()
         logger.info(f"Output topic: {output_config.get('topic')}")
 
-        return KafkaOutput(config=output_config)
+        return KafkaOutput(
+            config=output_config,
+            metrics_service=self.get_service_name(),
+            metrics_task_id=self.task_id,
+            metrics_topic=output_config.get('topic'),
+        )
 
     def get_model_config(self) -> Dict[str, Any]:
         """Get YOLOX model configuration."""

--- a/contanos/ai_service/base_app.py
+++ b/contanos/ai_service/base_app.py
@@ -1,11 +1,14 @@
 import argparse
 import logging
 from contextlib import asynccontextmanager
-from typing import Callable
+from typing import Callable, Optional
 
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_client import Info as PrometheusInfo
+from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_fastapi_instrumentator import metrics as instrumentator_metrics
 
 from .base_api import create_api_router
 from .models import HealthSummary
@@ -16,14 +19,46 @@ def create_ai_service_app(config: ServiceConfig, service_manager_getter: Callabl
     """Create a FastAPI application for an AI service with common setup."""
     
     # lifespan context manager
+    instrumentator: Optional[Instrumentator] = None
+    metrics_registered = False
+    service_info_metric: Optional[PrometheusInfo] = None
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        nonlocal instrumentator, metrics_registered, service_info_metric
+
         logging.info(f"{config.service_name} Starting (lifespan startup)...")
+
+        if instrumentator is None:
+            instrumentator = Instrumentator()
+            instrumentator.add(instrumentator_metrics.default())
+
+            service_info_metric = PrometheusInfo(
+                "ai_service_info",
+                "Static metadata about the AI microservice.",
+            )
+
+            def _record_service_info(_: instrumentator_metrics.Info) -> None:
+                if service_info_metric is not None:
+                    service_info_metric.info({"service_name": config.service_name})
+
+            instrumentator.add(_record_service_info)
+
+        if service_info_metric is not None:
+            service_info_metric.info({"service_name": config.service_name})
+
+        if instrumentator is not None and not metrics_registered:
+            instrumentator.instrument(app).expose(app, include_in_schema=False)
+            metrics_registered = True
+
         manager = service_manager_getter()
         manager._start_monitoring()
-        yield  # App is running here
-        logging.info(f"{config.service_name} Shutting Down (lifespan shutdown)...")
-        await manager.cleanup_all()
+
+        try:
+            yield  # App is running here
+        finally:
+            logging.info(f"{config.service_name} Shutting Down (lifespan shutdown)...")
+            await manager.cleanup_all()
 
     app = FastAPI(
         title=config.service_name,

--- a/contanos/base_worker.py
+++ b/contanos/base_worker.py
@@ -1,16 +1,28 @@
 import asyncio
 import functools
 import logging
+import time
 from abc import abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict
 
+from contanos.metrics.prometheus import (
+    MetricsLabelContext,
+    service_frame_processing_seconds,
+    service_frames_errors_total,
+    service_frames_processed_total,
+)
+
 
 class BaseWorker:
-    def __init__(self, worker_id: int, device: str,
-                 model_config: Dict,
-                 input_interface,
-                 output_interface):
+    def __init__(
+        self,
+        worker_id: int,
+        device: str,
+        model_config: Dict,
+        input_interface,
+        output_interface,
+    ):
         self.worker_id = worker_id
         self.input_interface = input_interface
         self.output_interface = output_interface
@@ -18,6 +30,27 @@ class BaseWorker:
         self.device = device
         self._model_init()
         self._executor = ThreadPoolExecutor(max_workers=1)
+
+        service_name = "unknown"
+        task_id = None
+        if isinstance(model_config, dict):
+            service_name = model_config.get("service_name", service_name)
+            task_id = model_config.get("task_id")
+
+        topic = getattr(output_interface, "topic", None)
+        if topic is None:
+            topic = getattr(input_interface, "topic", None)
+        if topic is None and hasattr(input_interface, "interfaces"):
+            topic = "multi_input"
+        if topic is None:
+            topic = "unknown"
+
+        self._metrics_context = MetricsLabelContext(
+            service=service_name,
+            worker_id=str(worker_id),
+            topic=topic,
+            initial_task_id=task_id,
+        )
 
     @abstractmethod
     def _model_init(self):
@@ -35,27 +68,46 @@ class BaseWorker:
         loop = asyncio.get_running_loop()
 
         """Run the worker, reading from input and writing to output."""
-        # logging.info(f"Worker {self.worker_id} started on {self.device}")
         while True:
             try:
-                # logging.debug(f"Worker {self.worker_id} waiting for input data...")
                 inputs = await self.input_interface.read_data()
 
-                results = await loop.run_in_executor(
-                    self._executor,
-                    functools.partial(self._predict, inputs)
-                )
+                if inputs is None:
+                    continue
+
+                task_id = inputs.get("task_id") if isinstance(inputs, dict) else None
+                labels = self._metrics_context.labels_for(task_id)
+
+                start_time = time.perf_counter()
+                try:
+                    results = await loop.run_in_executor(
+                        self._executor,
+                        functools.partial(self._predict, inputs),
+                    )
+                except Exception:
+                    duration = time.perf_counter() - start_time
+                    service_frame_processing_seconds.labels(**labels).observe(duration)
+                    service_frames_errors_total.labels(**labels).inc()
+                    raise
+
+                duration = time.perf_counter() - start_time
+                service_frame_processing_seconds.labels(**labels).observe(duration)
+                service_frames_processed_total.labels(**labels).inc()
 
                 if results is not None:
                     output = self._format_results(results)
+                    if isinstance(output, dict) and isinstance(inputs, dict):
+                        output.setdefault("task_id", inputs.get("task_id"))
 
                     await self.output_interface.write_data(output)
-                    # self.results.append(results)  # Store for verification
-                    # logging.debug(f"Worker {self.worker_id} on {self.device} processed input -> output")
             except asyncio.TimeoutError:
                 logging.info(f"Worker {self.worker_id} on {self.device} timed out, stopping")
                 raise
             except Exception as e:
                 logging.error(f"Worker {self.worker_id} on {self.device} error: {e}")
                 raise
-        logging.info(f"Worker {self.worker_id} on {self.device} finished")
+
+    def get_metrics_labels(self, task_id: Any = None) -> Dict[str, str]:
+        """Expose metric labels for the current worker."""
+
+        return self._metrics_context.labels_for(task_id)

--- a/contanos/metrics/__init__.py
+++ b/contanos/metrics/__init__.py
@@ -1,0 +1,21 @@
+"""Prometheus metric helpers for contanos services."""
+
+from .prometheus import *  # noqa: F401,F403
+
+__all__ = [
+    'MetricsLabelContext',
+    'service_frames_processed_total',
+    'service_frames_errors_total',
+    'service_frame_processing_seconds',
+    'service_input_queue_size',
+    'service_output_queue_size',
+    'service_frames_dropped_total',
+    'service_backpressure_events_total',
+    'service_pending_frames',
+    'service_interfaces_under_pressure',
+    'service_worker_restarts_total',
+    'service_messages_consumed_total',
+    'service_messages_produced_total',
+    'service_decode_errors_total',
+    'service_send_failures_total',
+]

--- a/contanos/metrics/prometheus.py
+++ b/contanos/metrics/prometheus.py
@@ -1,0 +1,169 @@
+"""Shared Prometheus metric definitions for contanos services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from prometheus_client import Counter, Gauge, Histogram
+
+LABEL_NAMES = ("service", "task_id", "worker_id", "topic")
+DEFAULT_TASK_ID = "unknown"
+
+
+# Core processing metrics
+service_frames_processed_total = Counter(
+    "service_frames_processed_total",
+    "Total number of frames processed by the worker stage.",
+    LABEL_NAMES,
+)
+
+service_frames_errors_total = Counter(
+    "service_frames_errors_total",
+    "Total number of frames that failed during processing.",
+    LABEL_NAMES,
+)
+
+service_frame_processing_seconds = Histogram(
+    "service_frame_processing_seconds",
+    "Latency in seconds for processing a single frame.",
+    LABEL_NAMES,
+    buckets=(
+        0.001,
+        0.005,
+        0.01,
+        0.02,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1,
+        2,
+        5,
+        10,
+    ),
+)
+
+
+# Queue depth gauges
+service_input_queue_size = Gauge(
+    "service_input_queue_size",
+    "Current depth of the service input queue.",
+    LABEL_NAMES,
+)
+
+service_output_queue_size = Gauge(
+    "service_output_queue_size",
+    "Current depth of the service output queue.",
+    LABEL_NAMES,
+)
+
+
+# Backpressure and drop monitoring
+service_frames_dropped_total = Counter(
+    "service_frames_dropped_total",
+    "Total number of frames dropped because of timeouts or overflow.",
+    LABEL_NAMES,
+)
+
+service_backpressure_events_total = Counter(
+    "service_backpressure_events_total",
+    "Total number of backpressure events detected by the service.",
+    LABEL_NAMES,
+)
+
+service_pending_frames = Gauge(
+    "service_pending_frames",
+    "Number of frames pending synchronization before inference.",
+    LABEL_NAMES,
+)
+
+service_interfaces_under_pressure = Gauge(
+    "service_interfaces_under_pressure",
+    "Number of upstream interfaces currently under backpressure.",
+    LABEL_NAMES,
+)
+
+
+# Worker lifecycle
+service_worker_restarts_total = Counter(
+    "service_worker_restarts_total",
+    "Total number of worker restart attempts.",
+    LABEL_NAMES,
+)
+
+
+# Kafka I/O specific metrics
+service_messages_consumed_total = Counter(
+    "service_messages_consumed_total",
+    "Total number of messages consumed from Kafka topics.",
+    LABEL_NAMES,
+)
+
+service_messages_produced_total = Counter(
+    "service_messages_produced_total",
+    "Total number of messages produced to Kafka topics.",
+    LABEL_NAMES,
+)
+
+service_decode_errors_total = Counter(
+    "service_decode_errors_total",
+    "Total number of decode errors while consuming Kafka messages.",
+    LABEL_NAMES,
+)
+
+service_send_failures_total = Counter(
+    "service_send_failures_total",
+    "Total number of failures when sending Kafka messages.",
+    LABEL_NAMES,
+)
+
+
+@dataclass
+class MetricsLabelContext:
+    """Helper for reusing Prometheus labels with dynamic task ids."""
+
+    service: str
+    worker_id: str
+    topic: str
+    initial_task_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self._base_labels = {
+            "service": self.service or "unknown",
+            "worker_id": str(self.worker_id) if self.worker_id is not None else "unknown",
+            "topic": self.topic or "unknown",
+        }
+        initial = self.initial_task_id or DEFAULT_TASK_ID
+        self._label_cache: Dict[str, Dict[str, str]] = {}
+        self._current_task_id = DEFAULT_TASK_ID
+        self.labels_for(initial)
+
+    def labels_for(self, task_id: Optional[str]) -> Dict[str, str]:
+        """Return labels for the provided task id and cache the result."""
+
+        normalized = str(task_id) if task_id else DEFAULT_TASK_ID
+        if normalized not in self._label_cache:
+            labels = {**self._base_labels, "task_id": normalized}
+            self._label_cache[normalized] = labels
+        self._current_task_id = normalized
+        return self._label_cache[normalized]
+
+    def with_metric(self, metric, task_id: Optional[str] = None):
+        """Return a labelled child for the provided metric."""
+
+        labels = self.labels_for(task_id or self._current_task_id)
+        return metric.labels(**labels)
+
+    @property
+    def current_task_id(self) -> str:
+        return self._current_task_id
+
+    @property
+    def current_labels(self) -> Dict[str, str]:
+        """Return the cached labels for the current task id."""
+
+        if self._current_task_id not in self._label_cache:
+            self.labels_for(self._current_task_id)
+        return self._label_cache[self._current_task_id]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,7 @@ pillow==11.3.0
 platformdirs==4.3.8
 pluggy==1.6.0
 prometheus_client==0.22.1
+prometheus-fastapi-instrumentator==7.1.0
 prompt_toolkit==3.0.51
 protobuf==6.31.1
 pydantic==2.11.7


### PR DESCRIPTION
## Summary
- add a contanos.metrics.prometheus module that centralizes counters, gauges, and histograms for service instrumentation
- record inference latency and success/failure counters in BaseWorker while reporting worker restarts from BaseService
- extend Kafka I/O and MultiInput interfaces plus service factories to emit queue, backpressure, and drop metrics with task-aware labels
- instrument the FastAPI backend ingestion pipeline with dedicated Prometheus metrics for segment publishing, task lifecycle, and completion waits, including default gauge initialization via the shared instrumentator

## Testing
- pytest *(fails: missing libGL.so.1 and fastapi_backend import dependencies in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d11f7a2338832b8fd4f606b0c0f846