### PR TITLE
Add Prometheus instrumentation across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ infrastructure (Kafka, Zookeeper, RTSP server, MongoDB) is provided via Docker C
 - FastAPI Backend (orchestrator + UI)
     - Starts/stops services, manages Kafka topics, exposes dashboard and APIs
 
+All FastAPI services (backend and AI microservices) expose Prometheus metrics at `/metrics` for scraping.
+
 ## Quick start (with Docker infrastructure)
 
 1) Start base services via Docker (Kafka, Zookeeper, RTSP, MongoDB)
@@ -138,6 +140,8 @@ Backend APIs (selected)
 - Annotation helpers
     - GET `/api/annotation/{task_id}/rtsp_url`, `/api/annotation/{task_id}/videos`,
       `/api/annotation/{task_id}/download/{filename}`, `/api/annotation/{task_id}/status`
+- Observability
+    - GET `/metrics` Prometheus metrics for the backend (each AI microservice exposes the same endpoint)
 
 Data formats (high level)
 

--- a/apps/fastapi_backend/main.py
+++ b/apps/fastapi_backend/main.py
@@ -3,12 +3,16 @@ FastAPI backend for multi-user AI video analysis platform.
 Refactored modular version.
 """
 from contextlib import asynccontextmanager
+from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
+from prometheus_client import Info as PrometheusInfo
+from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_fastapi_instrumentator import metrics as instrumentator_metrics
 from starlette.responses import FileResponse
 
 from config import APP_TITLE, APP_VERSION, STATIC_DIR, CORS_SETTINGS, logger, FRONTEND_DIST_DIR, UPLOAD_DIR
@@ -22,10 +26,39 @@ from routes.video import router as video_router
 from routes.websocket_pose import router as websocket_pose_router
 
 
+instrumentator: Optional[Instrumentator] = None
+metrics_registered: bool = False
+backend_info_metric: Optional[PrometheusInfo] = None
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan management."""
+    global instrumentator, metrics_registered, backend_info_metric
+
     logger.info("Starting AI Video Analysis Platform...")
+
+    if instrumentator is None:
+        instrumentator = Instrumentator()
+        instrumentator.add(instrumentator_metrics.default())
+
+        backend_info_metric = PrometheusInfo(
+            "fastapi_backend_info",
+            "Static metadata about the FastAPI backend service.",
+        )
+
+        def _record_backend_info(_: instrumentator_metrics.Info) -> None:
+            if backend_info_metric is not None:
+                backend_info_metric.info({"service_name": APP_TITLE})
+
+        instrumentator.add(_record_backend_info)
+
+    if backend_info_metric is not None:
+        backend_info_metric.info({"service_name": APP_TITLE})
+
+    if instrumentator is not None and not metrics_registered:
+        instrumentator.instrument(app).expose(app, include_in_schema=False)
+        metrics_registered = True
 
     # Initialize all services
     await initialize_services()

--- a/contanos/ai_service/base_app.py
+++ b/contanos/ai_service/base_app.py
@@ -1,11 +1,14 @@
 import argparse
 import logging
 from contextlib import asynccontextmanager
-from typing import Callable
+from typing import Callable, Optional
 
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_client import Info as PrometheusInfo
+from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_fastapi_instrumentator import metrics as instrumentator_metrics
 
 from .base_api import create_api_router
 from .models import HealthSummary
@@ -16,14 +19,46 @@ def create_ai_service_app(config: ServiceConfig, service_manager_getter: Callabl
     """Create a FastAPI application for an AI service with common setup."""
     
     # lifespan context manager
+    instrumentator: Optional[Instrumentator] = None
+    metrics_registered = False
+    service_info_metric: Optional[PrometheusInfo] = None
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        nonlocal instrumentator, metrics_registered, service_info_metric
+
         logging.info(f"{config.service_name} Starting (lifespan startup)...")
+
+        if instrumentator is None:
+            instrumentator = Instrumentator()
+            instrumentator.add(instrumentator_metrics.default())
+
+            service_info_metric = PrometheusInfo(
+                "ai_service_info",
+                "Static metadata about the AI microservice.",
+            )
+
+            def _record_service_info(_: instrumentator_metrics.Info) -> None:
+                if service_info_metric is not None:
+                    service_info_metric.info({"service_name": config.service_name})
+
+            instrumentator.add(_record_service_info)
+
+        if service_info_metric is not None:
+            service_info_metric.info({"service_name": config.service_name})
+
+        if instrumentator is not None and not metrics_registered:
+            instrumentator.instrument(app).expose(app, include_in_schema=False)
+            metrics_registered = True
+
         manager = service_manager_getter()
         manager._start_monitoring()
-        yield  # App is running here
-        logging.info(f"{config.service_name} Shutting Down (lifespan shutdown)...")
-        await manager.cleanup_all()
+
+        try:
+            yield  # App is running here
+        finally:
+            logging.info(f"{config.service_name} Shutting Down (lifespan shutdown)...")
+            await manager.cleanup_all()
 
     app = FastAPI(
         title=config.service_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,7 @@ pillow==11.3.0
 platformdirs==4.3.8
 pluggy==1.6.0
 prometheus_client==0.22.1
+prometheus-fastapi-instrumentator==7.1.0
 prompt_toolkit==3.0.51
 protobuf==6.31.1
 pydantic==2.11.7


### PR DESCRIPTION
## Summary
- add prometheus-fastapi-instrumentator as a dependency
- instrument AI service base apps and the FastAPI backend with Prometheus metrics
- document the new `/metrics` observability endpoint in the README

## Testing
- pytest *(fails: libGL.so.1 missing and fastapi_backend module import errors in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d11f7a2338832b8fd4f606b0c0f846